### PR TITLE
Fix cross publishing involving a Java subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,8 @@
+lazy val scala212 = "2.12.8"
+lazy val scala211 = "2.11.12"
+lazy val bothScalaVersions = List(scala212, scala211)
+
+ThisBuild / scalaVersion := scala212
 
 val disableDocs = Seq[Setting[_]](
   sources in (Compile, doc) := Seq.empty,
@@ -10,29 +15,22 @@ val disablePublishing = Seq[Setting[_]](
 )
 
 val javaOnly = Seq[Setting[_]](
-  // DO NOT SET crossScalaVersions in java project
+  // set crossScalaVersions to just one scalaVersion
+  crossScalaVersions := List(scala212),
   crossPaths := false,
   autoScalaLibrary := false
 )
 
-lazy val onlyOnce = new java.util.concurrent.CountDownLatch(1)
-def countDown: Boolean = {
-  val count = onlyOnce.getCount
-  onlyOnce.countDown()
-  count == 0
-}
-
 lazy val `java-project` = (project in file("java-project"))
   .settings(disableDocs)
   .settings(javaOnly)
-  .settings(
-    skip in publish := countDown // publish only once.
-  )
 
 lazy val `scala-project` = (project in file("scala-project"))
-  .settings(disableDocs)
   .dependsOn(`java-project`)
-  .aggregate(`java-project`)
+  .settings(disableDocs)
+  .settings(
+    crossScalaVersions := bothScalaVersions
+  )
 
 import ReleaseTransformations._
 lazy val root = (project in file("."))
@@ -41,7 +39,7 @@ lazy val root = (project in file("."))
     name := "publish-with-java-project",
     //logLevel := Level.Debug,
     releaseCrossBuild := true, // must be set in root project
-    crossScalaVersions := Seq("2.11.6", scalaVersion.value), // set in root project
+    crossScalaVersions := Nil, // set crossScalaVersions to Nil
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,              // : ReleaseStep
       inquireVersions,                        // : ReleaseStep

--- a/java-project/src/main/java/foo/Foo.java
+++ b/java-project/src/main/java/foo/Foo.java
@@ -1,0 +1,5 @@
+package foo;
+
+public class Foo {
+
+}

--- a/scala-project/src/main/scala/foo/Bar.scala
+++ b/scala-project/src/main/scala/foo/Bar.scala
@@ -1,0 +1,5 @@
+package foo
+
+class Bar {
+  val x = new Foo
+}


### PR DESCRIPTION
1. Root subproject must have its `crossScalaVersions` set to `Nil`. Otherwise aggregation will cause double publishing.
2. scala-project should have no aggregation. Otherwise aggregation will cause double publishing.
3. scala-project should have `crossScalaVersions` set to all Scala versions it supports.
4. java-project should have `crossScalaVersions` set to exactly one Scala version, normally `scala212`.